### PR TITLE
fixes email function not working #189

### DIFF
--- a/SpecialEmailPage.php
+++ b/SpecialEmailPage.php
@@ -265,8 +265,8 @@ class SpecialEmailPage extends SpecialPage {
 			if ( $send ) {
 
 				$mail           = new PHPMailer\PHPMailer\PHPMailer;
-				// or $mail->IsSMTP();
-				$mail->isSendmail();
+				// or $mail->isSendmail();
+				$mail->IsSMTP();
 				
 				$mail->CharSet  = $wgEmailPageCharSet;
 				$mail->From     = $this->from;

--- a/SpecialEmailPage.php
+++ b/SpecialEmailPage.php
@@ -206,7 +206,6 @@ class SpecialEmailPage extends SpecialPage {
 		// Compose the wikitext content of the page to send
 		$title = Title::newFromText( $this->title );
 		
-		// if ( !$title->isContentPage() ) {
 		if ( $title->isSpecialPage() ) {
 			$out->addWikiTextAsContent( wfMessage( 'ea-no-content-page' )->text() );
 			return false;
@@ -265,7 +264,6 @@ class SpecialEmailPage extends SpecialPage {
 			if ( $send ) {
 
 				$mail           = new PHPMailer\PHPMailer\PHPMailer;
-				// or $mail->IsSMTP();
 				$mail->isSendmail();
 				
 				$mail->CharSet  = $wgEmailPageCharSet;

--- a/SpecialEmailPage.php
+++ b/SpecialEmailPage.php
@@ -205,6 +205,13 @@ class SpecialEmailPage extends SpecialPage {
 
 		// Compose the wikitext content of the page to send
 		$title = Title::newFromText( $this->title );
+		
+		// if ( !$title->isContentPage() ) {
+		if ( $title->isSpecialPage() ) {
+			$out->addWikiTextAsContent( wfMessage( 'ea-no-content-page' )->text() );
+			return false;
+		}
+		
 		$opt   = ParserOptions::newFromContext( $this->getContext() );
 		$page  = new Article( $title );
 		$parser = \MediaWiki\MediaWikiServices::getInstance()->getParser();
@@ -258,6 +265,9 @@ class SpecialEmailPage extends SpecialPage {
 			if ( $send ) {
 
 				$mail           = new PHPMailer\PHPMailer\PHPMailer;
+				// or $mail->IsSMTP();
+				$mail->isSendmail();
+				
 				$mail->CharSet  = $wgEmailPageCharSet;
 				$mail->From     = $this->from;
 				$mail->FromName = User::whoIsReal( $user->getId() );

--- a/SpecialEmailPage.php
+++ b/SpecialEmailPage.php
@@ -265,8 +265,8 @@ class SpecialEmailPage extends SpecialPage {
 			if ( $send ) {
 
 				$mail           = new PHPMailer\PHPMailer\PHPMailer;
-				// or $mail->isSendmail();
-				$mail->IsSMTP();
+				// or $mail->IsSMTP();
+				$mail->isSendmail();
 				
 				$mail->CharSet  = $wgEmailPageCharSet;
 				$mail->From     = $this->from;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,6 +14,7 @@
 	"ea-listrecipients": "Listing {{PLURAL:$1|recipient|$1 recipients}}",
 	"ea-error": "'''Error sending [[$1]]:''' ''$2''",
 	"ea-denied": "Permission denied",
+	"ea-no-content-page": "No content page",
 	"ea-sent": "Page [[$1]] sent successfully to '''$2''' {{PLURAL:$2|recipient|recipients}} by [[{{ns:User}}:$3|$3]].",
 	"ea-compose": "Compose content",
 	"ea-show": "View recipient list",


### PR DESCRIPTION
* refs https://github.com/debtcompliance/mediawiki/issues/189
* adds an error message when used on SpecialPages

please check both `$mail->isSendmail();` and ` $mail->IsSMTP();`

composer install must be performed in the extension's directory
